### PR TITLE
Add Inbuilt tools API abstraction

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Ballerina MistralAI Model Provider Library
 
 [![Build](https://github.com/ballerina-platform/module-ballerinax-ai.mistral/workflows/CI/badge.svg)](https://github.com/ballerina-platform/module-ballerinax-ai.mistral/actions?query=workflow%3ACI)
-[![GitHub Last Commit](https://img.shields.io/github/last-commit/ballerina-platform/module-ballerinax-ai.mistral.svg)](https://github.com/ballerina-platform/module-ballerinax-ai.mistral/commits/master)
+[![GitHub Last Commit](https://img.shields.io/github/last-commit/ballerina-platform/module-ballerinax-ai.mistral.svg)](https://github.com/ballerina-platform/module-ballerinax-ai.mistral/commits/main)
 [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 
 ## Overview

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -7,7 +7,7 @@ icon="icon.png"
 name = "ai.mistral"
 org = "ballerinax"
 repository = "https://github.com/ballerina-platform/module-ballerinax-ai.mistral"
-version = "1.2.2"
+version = "1.3.0"
 
 [platform.java21]
 graalvmCompatible = true
@@ -15,13 +15,13 @@ graalvmCompatible = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.lib"
 artifactId = "ai.mistral-native"
-version = "1.2.2"
-path = "../native/build/libs/ai.mistral-native-1.2.2-SNAPSHOT.jar"
+version = "1.3.0"
+path = "../native/build/libs/ai.mistral-native-1.3.0-SNAPSHOT.jar"
 
 [[dependency]]
 org="ballerina"
 name="ai"
-version="1.10.0"
+version="1.11.0"
 repository="local"
 
 [[dependency]]

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -7,7 +7,7 @@ icon="icon.png"
 name = "ai.mistral"
 org = "ballerinax"
 repository = "https://github.com/ballerina-platform/module-ballerinax-ai.mistral"
-version = "1.2.1"
+version = "1.2.2"
 
 [platform.java21]
 graalvmCompatible = true
@@ -15,5 +15,17 @@ graalvmCompatible = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.lib"
 artifactId = "ai.mistral-native"
-version = "1.2.1"
-path = "../native/build/libs/ai.mistral-native-1.2.1.jar"
+version = "1.2.2"
+path = "../native/build/libs/ai.mistral-native-1.2.2-SNAPSHOT.jar"
+
+[[dependency]]
+org="ballerina"
+name="ai"
+version="1.10.0"
+repository="local"
+
+[[dependency]]
+org="ballerina"
+name="data.jsondata"
+version="1.1.4"
+repository="local"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,7 +3,7 @@ id = "ai-mistral-compiler-plugin"
 class = "io.ballerina.lib.ai.mistral.AiMistralCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/ai.mistral-compiler-plugin-1.2.2-SNAPSHOT.jar"
+path = "../compiler-plugin/build/libs/ai.mistral-compiler-plugin-1.3.0-SNAPSHOT.jar"
 
 [[dependency]]
 path = "../compiler-plugin/build/libs/ballerina-to-openapi-2.3.0.jar"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,7 +3,7 @@ id = "ai-mistral-compiler-plugin"
 class = "io.ballerina.lib.ai.mistral.AiMistralCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/ai.mistral-compiler-plugin-1.2.1.jar"
+path = "../compiler-plugin/build/libs/ai.mistral-compiler-plugin-1.2.2-SNAPSHOT.jar"
 
 [[dependency]]
 path = "../compiler-plugin/build/libs/ballerina-to-openapi-2.3.0.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -93,7 +93,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "data.xmldata"
-version = "1.6.0"
+version = "1.6.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.object"}

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -5,12 +5,12 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.12.0"
+distribution-version = "2201.13.0"
 
 [[package]]
 org = "ballerina"
 name = "ai"
-version = "1.7.0"
+version = "1.10.0"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "data.jsondata"},
@@ -75,7 +75,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "crypto"
-version = "2.9.3"
+version = "2.10.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -84,7 +84,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "data.jsondata"
-version = "1.1.3"
+version = "1.1.4"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.object"}
@@ -93,7 +93,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "data.xmldata"
-version = "1.5.2"
+version = "1.6.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.object"}
@@ -113,7 +113,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.14.8"
+version = "2.15.4"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
@@ -267,7 +267,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "log"
-version = "2.14.0"
+version = "2.17.0"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -283,7 +283,7 @@ version = "1.2.0"
 [[package]]
 org = "ballerina"
 name = "mcp"
-version = "1.0.2"
+version = "1.0.3"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -304,7 +304,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "oauth2"
-version = "2.14.1"
+version = "2.15.0"
 dependencies = [
 	{org = "ballerina", name = "cache"},
 	{org = "ballerina", name = "crypto"},
@@ -317,7 +317,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.6.0"
+version = "1.7.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -334,7 +334,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "task"
-version = "2.11.0"
+version = "2.11.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"},
@@ -358,7 +358,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "time"
-version = "2.7.0"
+version = "2.8.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -409,7 +409,7 @@ dependencies = [
 [[package]]
 org = "ballerinax"
 name = "ai.mistral"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
 	{org = "ballerina", name = "ai"},
 	{org = "ballerina", name = "constraint"},

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -5,12 +5,12 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.13.0"
+distribution-version = "2201.12.0"
 
 [[package]]
 org = "ballerina"
 name = "ai"
-version = "1.10.0"
+version = "1.11.0"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "data.jsondata"},
@@ -113,7 +113,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.15.4"
+version = "2.14.9"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
@@ -267,7 +267,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "log"
-version = "2.17.0"
+version = "2.14.0"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -304,7 +304,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "oauth2"
-version = "2.15.0"
+version = "2.14.1"
 dependencies = [
 	{org = "ballerina", name = "cache"},
 	{org = "ballerina", name = "crypto"},
@@ -317,7 +317,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.7.0"
+version = "1.6.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -409,7 +409,7 @@ dependencies = [
 [[package]]
 org = "ballerinax"
 name = "ai.mistral"
-version = "1.2.2"
+version = "1.3.0"
 dependencies = [
 	{org = "ballerina", name = "ai"},
 	{org = "ballerina", name = "constraint"},

--- a/ballerina/model-provider.bal
+++ b/ballerina/model-provider.bal
@@ -86,19 +86,19 @@ public isolated client class ModelProvider {
     # + stop - Stop sequence to stop the completion
     # + return - Returns an array of ai:ChatAssistantMessage or an ai:LlmError in case of failures
     isolated remote function chat(ai:ChatMessage[]|ai:ChatUserMessage messages,
-            (ai:ChatCompletionFunctions|ai:InbuiltModelTool)[] tools = [], string? stop = ())
+            (ai:ChatCompletionFunctions|ai:BuiltInTool)[] tools = [], string? stop = ())
         returns ai:ChatAssistantMessage|ai:Error {
         string[] unsupportedTools = [];
         ai:ChatCompletionFunctions[] functionTools = [];
         foreach var tool in tools {
-            if tool is ai:InbuiltModelTool {
+            if tool is ai:BuiltInTool {
                 unsupportedTools.push(tool.name);
             } else {
                 functionTools.push(tool);
             }
         }
         if unsupportedTools.length() > 0 {
-            return error ai:Error(string `Inbuilt tools [${string:'join(", ", ...unsupportedTools)}] are not supported.`);
+            return error ai:Error(string `Built-in tools [${string:'join(", ", ...unsupportedTools)}] are not supported.`);
         }
 
         observe:ChatSpan span = observe:createChatSpan(self.modelType);

--- a/ballerina/model-provider.bal
+++ b/ballerina/model-provider.bal
@@ -85,8 +85,22 @@ public isolated client class ModelProvider {
     # + tools - Tool definitions to be used for the tool call
     # + stop - Stop sequence to stop the completion
     # + return - Returns an array of ai:ChatAssistantMessage or an ai:LlmError in case of failures
-    isolated remote function chat(ai:ChatMessage[]|ai:ChatUserMessage messages, ai:ChatCompletionFunctions[] tools, string? stop = ())
+    isolated remote function chat(ai:ChatMessage[]|ai:ChatUserMessage messages,
+            (ai:ChatCompletionFunctions|ai:InbuiltModelTool)[] tools = [], string? stop = ())
         returns ai:ChatAssistantMessage|ai:Error {
+        string[] unsupportedTools = [];
+        ai:ChatCompletionFunctions[] functionTools = [];
+        foreach var tool in tools {
+            if tool is ai:InbuiltModelTool {
+                unsupportedTools.push(tool.name);
+            } else {
+                functionTools.push(tool);
+            }
+        }
+        if unsupportedTools.length() > 0 {
+            return error ai:Error(string `Inbuilt tools [${string:'join(", ", ...unsupportedTools)}] are not supported.`);
+        }
+
         observe:ChatSpan span = observe:createChatSpan(self.modelType);
         span.addProvider("mistral_ai");
         if stop is string {
@@ -107,10 +121,10 @@ public isolated client class ModelProvider {
             maxTokens: self.maxTokens
         };
 
-        if tools.length() > 0 {
-            span.addTools(tools);
+        if functionTools.length() > 0 {
+            span.addTools(functionTools);
             mistral:Function[] mistralFunctions = [];
-            foreach ai:ChatCompletionFunctions toolFunction in tools {
+            foreach ai:ChatCompletionFunctions toolFunction in functionTools {
                 mistral:Function mistralFunction = {
                     name: toolFunction.name,
                     description: toolFunction.description,

--- a/ballerina/tests/tests.bal
+++ b/ballerina/tests/tests.bal
@@ -380,3 +380,15 @@ function testChatWithBuiltInToolError() returns error? {
     test:assertTrue(errorMsg.includes("Built-in tools [web_search] are not supported."),
             string `expected built-in tool error, found: ${errorMsg}`);
 }
+
+@test:Config
+function testChatWithMixedToolsError() returns error? {
+    ai:ChatUserMessage userMsg = {role: "user", content: "Search the web for latest news"};
+    ai:BuiltInTool webSearchTool = {name: "web_search"};
+    ai:ChatCompletionFunctions functionTool = {name: "get_weather", description: "Get weather", parameters: {}};
+    ai:ChatAssistantMessage|ai:Error result = mistralProvider->chat(userMsg, [functionTool, webSearchTool]);
+    test:assertTrue(result is ai:Error);
+    string errorMsg = (<ai:Error>result).message();
+    test:assertTrue(errorMsg.includes("Built-in tools [web_search] are not supported."),
+            string `expected built-in tool error, found: ${errorMsg}`);
+}

--- a/ballerina/tests/tests.bal
+++ b/ballerina/tests/tests.bal
@@ -367,3 +367,16 @@ function testGenerateMethodWithArrayUnionRecord2() returns ai:Error? {
    Cricketers7[]|Cricketers8|error result = mistralProvider->generate(`Name a random world class cricketer`);
     test:assertTrue(result is Cricketers8);
 }
+
+// ===== Built-in tool tests =====
+
+@test:Config
+function testChatWithBuiltInToolError() returns error? {
+    ai:ChatUserMessage userMsg = {role: "user", content: "Search the web for latest news"};
+    ai:BuiltInTool webSearchTool = {name: "web_search"};
+    ai:ChatAssistantMessage|ai:Error result = mistralProvider->chat(userMsg, [webSearchTool]);
+    test:assertTrue(result is ai:Error);
+    string errorMsg = (<ai:Error>result).message();
+    test:assertTrue(errorMsg.includes("Built-in tools [web_search] are not supported."),
+            string `expected built-in tool error, found: ${errorMsg}`);
+}

--- a/build-config/resources/Ballerina.toml
+++ b/build-config/resources/Ballerina.toml
@@ -17,3 +17,15 @@ groupId = "io.ballerina.lib"
 artifactId = "ai.mistral-native"
 version = "@toml.version@"
 path = "../native/build/libs/ai.mistral-native-@project.version@.jar"
+
+[[dependency]]
+org="ballerina"
+name="ai"
+version="1.10.0"
+repository="local"
+
+[[dependency]]
+org="ballerina"
+name="data.jsondata"
+version="1.1.4"
+repository="local"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.caching=true
 group=io.ballerina.lib
 version=1.2.2-SNAPSHOT
-ballerinaLangVersion=2201.12.0
+ballerinaLangVersion=2201.13.0
 
 shadowJarPluginVersion=8.1.1
 downloadPluginVersion=5.4.0

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,7 +1,7 @@
 org.gradle.caching=true
 group=io.ballerina.lib
-version=1.2.2-SNAPSHOT
-ballerinaLangVersion=2201.13.0
+version=1.3.0-SNAPSHOT
+ballerinaLangVersion=2201.12.0
 
 shadowJarPluginVersion=8.1.1
 downloadPluginVersion=5.4.0


### PR DESCRIPTION
Add built-in tool abstraction implementation

Fixes:
https://github.com/wso2-enterprise/integration-engineering/issues/80

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Overview

This pull request implements built-in tool abstraction support for the Mistral AI module. The changes introduce a new tool filtering mechanism in the model provider while updating dependencies to support enhanced functionality.

## Key Changes

### Core Functionality
- Enhanced the `ModelProvider.chat()` method to accept and validate both standard chat completion functions and built-in tools
- Implemented runtime validation that separates valid functions from built-in tools, ensuring only appropriate tools are forwarded to the Mistral API
- Added error handling that provides clear feedback when unsupported tool types are encountered

### Dependency Updates
- Updated the `ai` package dependency from 1.7.0 to 1.10.0 to leverage enhanced tool handling capabilities
- Added explicit dependencies on `ai` (1.10.0) and `data.jsondata` (1.1.4) packages
- Updated Ballerina distribution version from 2201.12.0 to 2201.13.0
- Bumped multiple supporting packages (crypto, http, log, oauth2, observe, time, and others) to latest stable versions

### Version Bump
- Updated package version from 1.2.1 to 1.2.2
- Updated native and compiler plugin artifacts to corresponding 1.2.2-SNAPSHOT builds

## Impact
These changes establish a foundation for built-in tool support while maintaining backward compatibility through proper input validation and type filtering, ensuring the system gracefully handles different tool configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->