### PR TITLE
Add chunk type support to generate method

### DIFF
--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -7,7 +7,7 @@ icon="icon.png"
 name = "ai.mistral"
 org = "ballerinax"
 repository = "https://github.com/ballerina-platform/module-ballerinax-ai.mistral"
-version = "1.2.2"
+version = "1.2.3"
 
 [platform.java21]
 graalvmCompatible = true
@@ -15,5 +15,5 @@ graalvmCompatible = true
 [[platform.java21.dependency]]
 groupId = "io.ballerina.lib"
 artifactId = "ai.mistral-native"
-version = "1.2.2"
-path = "../native/build/libs/ai.mistral-native-1.2.2.jar"
+version = "1.2.3"
+path = "../native/build/libs/ai.mistral-native-1.2.3-SNAPSHOT.jar"

--- a/ballerina/CompilerPlugin.toml
+++ b/ballerina/CompilerPlugin.toml
@@ -3,7 +3,7 @@ id = "ai-mistral-compiler-plugin"
 class = "io.ballerina.lib.ai.mistral.AiMistralCompilerPlugin"
 
 [[dependency]]
-path = "../compiler-plugin/build/libs/ai.mistral-compiler-plugin-1.2.2.jar"
+path = "../compiler-plugin/build/libs/ai.mistral-compiler-plugin-1.2.3-SNAPSHOT.jar"
 
 [[dependency]]
 path = "../compiler-plugin/build/libs/ballerina-to-openapi-2.3.0.jar"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -113,7 +113,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.14.9"
+version = "2.14.10"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
@@ -409,7 +409,7 @@ dependencies = [
 [[package]]
 org = "ballerinax"
 name = "ai.mistral"
-version = "1.2.2"
+version = "1.2.3"
 dependencies = [
 	{org = "ballerina", name = "ai"},
 	{org = "ballerina", name = "constraint"},
@@ -428,7 +428,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "mistral"
-version = "1.0.1"
+version = "1.0.2"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "data.jsondata"},

--- a/ballerina/model-provider.bal
+++ b/ballerina/model-provider.bal
@@ -26,6 +26,9 @@ const DEFAULT_MAX_TOKEN_COUNT = 512;
 const DEFAULT_TEMPERATURE = 0.7d;
 
 # MistralAiProvider is a client class that provides an interface for interacting with Mistral AI Large Language Models.
+@display {
+    label: "Mistral Model Provider"
+}
 public isolated client class ModelProvider {
     *ai:ModelProvider;
     private final mistral:Client llmClient;

--- a/ballerina/provider_utils.bal
+++ b/ballerina/provider_utils.bal
@@ -96,14 +96,14 @@ isolated function generateChatCreationContent(ai:Prompt prompt)
         anydata insertion = insertions[i];
         string str = strings[i + 1];
 
-        if insertion is ai:Document {
+        if insertion is ai:Document|ai:Chunk {
             addTextContentPart(buildTextContentPart(accumulatedTextContent), contentParts);
             accumulatedTextContent = "";
             check addDocumentContentPart(insertion, contentParts);
-        } else if insertion is ai:Document[] {
+        } else if insertion is (ai:Document|ai:Chunk)[] {
             addTextContentPart(buildTextContentPart(accumulatedTextContent), contentParts);
             accumulatedTextContent = "";
-            foreach ai:Document doc in insertion {
+            foreach ai:Document|ai:Chunk doc in insertion {
                 check addDocumentContentPart(doc, contentParts);
             }
         } else {
@@ -116,8 +116,8 @@ isolated function generateChatCreationContent(ai:Prompt prompt)
     return contentParts;
 }
 
-isolated function addDocumentContentPart(ai:Document doc, DocumentContentPart[] contentParts) returns ai:Error? {
-    if doc is ai:TextDocument {
+isolated function addDocumentContentPart(ai:Document|ai:Chunk doc, DocumentContentPart[] contentParts) returns ai:Error? {
+    if doc is ai:TextDocument|ai:TextChunk {
         return addTextContentPart(buildTextContentPart(doc.content), contentParts);
     } else if doc is ai:ImageDocument {
         return contentParts.push(check buildImageContentPart(doc));

--- a/ballerina/tests/test_utils.bal
+++ b/ballerina/tests/test_utils.bal
@@ -49,6 +49,14 @@ isolated function getExpectedParameterSchema(string message) returns map<json> {
         return expectedParameterSchemaStringForRateBlog2;
     }
 
+    if message.startsWith("How would you rate these text chunks") {
+        return expectedParameterSchemaStringForRateBlog5;
+    }
+
+    if message.startsWith("How would you rate this text chunk") {
+        return expectedParameterSchemaStringForRateBlog;
+    }
+
     if message.startsWith("How would you rate this") {
         return expectedParameterSchemaStringForRateBlog;
     }
@@ -201,6 +209,14 @@ isolated function getTheMockLLMResult(string message) returns map<json> {
         return review;
     }
 
+    if message.startsWith("How would you rate these text chunks") {
+        return {"result": [review, review]};
+    }
+
+    if message.startsWith("How would you rate this text chunk") {
+        return {result: 4};
+    }
+
     if message.startsWith("How would you rate this") {
         return {result: 4};
     }
@@ -321,6 +337,14 @@ isolated function getExpectedContentParts(string message) returns (map<anydata>)
 
     if message.startsWith("How would you rate this text blog") {
         return expectedContentPartsForRateBlog8;
+    }
+
+    if message.startsWith("How would you rate these text chunks") {
+        return expectedContentPartsForTextChunkArray;
+    }
+
+    if message.startsWith("How would you rate this text chunk") {
+        return expectedContentPartsForTextChunk;
     }
 
     if message.startsWith("How would you rate this") {

--- a/ballerina/tests/test_values.bal
+++ b/ballerina/tests/test_values.bal
@@ -150,6 +150,38 @@ final readonly & map<anydata>[] expectedContentPartsForCountry = [
     {"type": "text", "text": "Which country is known as the pearl of the Indian Ocean?"}
 ];
 
+final readonly & map<anydata>[] expectedContentPartsForTextChunk = [
+    {"type": "text", "text": "How would you rate this text chunk content out of 10. "},
+    {
+        "type": "text",
+        "text": "Title: Tips for Growing a Beautiful Garden Content: " +
+        "Spring is the perfect time to start your garden. \n        Begin by preparing your soil with " +
+        "organic compost and ensure proper drainage. \n        Choose plants suitable for your climate zone, " +
+        "and remember to water them regularly. \n        Don't forget to mulch to retain moisture and prevent weeds."
+    },
+    {"type": "text", "text": "."}
+];
+
+final readonly & map<anydata>[] expectedContentPartsForTextChunkArray = [
+    {"type": "text", "text": "How would you rate these text chunks out of 10. "},
+    {
+        "type": "text",
+        "text": "Title: Tips for Growing a Beautiful Garden Content: " +
+        "Spring is the perfect time to start your garden. \n        Begin by preparing your soil with " +
+        "organic compost and ensure proper drainage. \n        Choose plants suitable for your climate zone, " +
+        "and remember to water them regularly. \n        Don't forget to mulch to retain moisture and prevent weeds."
+    },
+    {
+        "type": "text",
+        "text": "Title: Tips for Growing a Beautiful Garden Content: " +
+        "Spring is the perfect time to start your garden. \n        " +
+        "Begin by preparing your soil with organic compost and ensure proper drainage. \n        " +
+        "Choose plants suitable for your climate zone, and remember to water them regularly. \n        " +
+        "Don't forget to mulch to retain moisture and prevent weeds."
+    },
+    {"type": "text", "text": ". Thank you!"}
+];
+
 const expectedParameterSchemaStringForRateBlog =
     {"type": "object", "properties": {"result": {"type": "integer"}}};
 

--- a/ballerina/tests/tests.bal
+++ b/ballerina/tests/tests.bal
@@ -80,25 +80,17 @@ function testGenerateMethodWithTextDocumentArray() returns error? {
 }
 
 @test:Config
-function testGenerateMethodWithTextChunk() returns ai:Error? {
-    ai:TextChunk chunk = {
-        content: string `Title: ${blog1.title} Content: ${blog1.content}`
-    };
-    int maxScore = 10;
-
-    int|error rating = mistralProvider->generate(`How would you rate this text chunk content out of ${maxScore}. ${chunk}.`);
-    test:assertEquals(rating, 4);
-}
-
-@test:Config
-function testGenerateMethodWithTextChunkArray() returns error? {
+function testGenerateMethodWithTextChunk() returns error? {
     ai:TextChunk chunk = {
         content: string `Title: ${blog1.title} Content: ${blog1.content}`
     };
     ai:TextChunk[] chunks = [chunk, chunk];
     int maxScore = 10;
-    Review r = check reviewStr.fromJsonStringWithType(Review);
 
+    int|error rating = mistralProvider->generate(`How would you rate this text chunk content out of ${maxScore}. ${chunk}.`);
+    test:assertEquals(rating, 4);
+
+    Review r = check reviewStr.fromJsonStringWithType(Review);
     ReviewArray|error result = mistralProvider->generate(`How would you rate these text chunks out of ${maxScore}. ${chunks}. Thank you!`);
     test:assertEquals(result, [r, r]);
 }

--- a/ballerina/tests/tests.bal
+++ b/ballerina/tests/tests.bal
@@ -87,11 +87,11 @@ function testGenerateMethodWithTextChunk() returns error? {
     ai:TextChunk[] chunks = [chunk, chunk];
     int maxScore = 10;
 
-    int|error rating = mistralProvider->generate(`How would you rate this text chunk content out of ${maxScore}. ${chunk}.`);
+    int rating = check mistralProvider->generate(`How would you rate this text chunk content out of ${maxScore}. ${chunk}.`);
     test:assertEquals(rating, 4);
 
     Review r = check reviewStr.fromJsonStringWithType(Review);
-    ReviewArray|error result = mistralProvider->generate(`How would you rate these text chunks out of ${maxScore}. ${chunks}. Thank you!`);
+    ReviewArray result = check mistralProvider->generate(`How would you rate these text chunks out of ${maxScore}. ${chunks}. Thank you!`);
     test:assertEquals(result, [r, r]);
 }
 

--- a/ballerina/tests/tests.bal
+++ b/ballerina/tests/tests.bal
@@ -80,6 +80,30 @@ function testGenerateMethodWithTextDocumentArray() returns error? {
 }
 
 @test:Config
+function testGenerateMethodWithTextChunk() returns ai:Error? {
+    ai:TextChunk chunk = {
+        content: string `Title: ${blog1.title} Content: ${blog1.content}`
+    };
+    int maxScore = 10;
+
+    int|error rating = mistralProvider->generate(`How would you rate this text chunk content out of ${maxScore}. ${chunk}.`);
+    test:assertEquals(rating, 4);
+}
+
+@test:Config
+function testGenerateMethodWithTextChunkArray() returns error? {
+    ai:TextChunk chunk = {
+        content: string `Title: ${blog1.title} Content: ${blog1.content}`
+    };
+    ai:TextChunk[] chunks = [chunk, chunk];
+    int maxScore = 10;
+    Review r = check reviewStr.fromJsonStringWithType(Review);
+
+    ReviewArray|error result = mistralProvider->generate(`How would you rate these text chunks out of ${maxScore}. ${chunks}. Thank you!`);
+    test:assertEquals(result, [r, r]);
+}
+
+@test:Config
 function testGenerateMethodWithImageDocumentWithBinaryData() returns ai:Error? {
     ai:ImageDocument img = {
         content: sampleBinaryData


### PR DESCRIPTION
## Purpose

Fixes: [https://github.com/wso2/product-integrator/issues/370](https://github.com/wso2/product-integrator/issues/370)

- This is tested with credentials manually 
- Test for textChunk and textChunk[]

## Examples

## Checklist
- [x] Linked to an issue
- [ ] Updated the changelog
- [x] Added tests
- [ ] Updated the spec
- [ ] Checked native-image compatibility


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This PR extends the Mistral Model Provider's `generate` method to support `ai:TextChunk` inputs in addition to existing document types. Previously, the method would fail when attempting to use TextChunk objects in prompts, producing an error about unsupported document types.

## Changes

**Core Functionality Changes:**
- Updated `generateChatCreationContent` and `addDocumentContentPart` functions in `provider_utils.bal` to accept and process both `ai:Document` and `ai:Chunk` types
- Added type handling for `ai:TextChunk` to enable TextChunk objects to be processed alongside TextDocument inputs
- Maintains backward compatibility with existing Document-based inputs

**Enhancements:**
- Added `@display` annotation to `ModelProvider` class for improved UI labeling
- Incremented package version from 1.2.2 to 1.2.3
- Updated platform dependencies and native library references

**Test Coverage:**
- Added test utilities to recognize and handle text chunk-related prompt patterns
- Introduced new test constants for expected outputs when using single TextChunk and TextChunk array inputs
- Added comprehensive test cases validating `generate` method with TextChunk and TextChunk array scenarios

**Dependencies:**
- Updated `ballerina:http` to 2.14.10
- Updated internal module dependencies to reflect the new version

<!-- end of auto-generated comment: release notes by coderabbit.ai -->