### PR TITLE
Update/max token

### DIFF
--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -113,7 +113,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.14.10"
+version = "2.14.11"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
@@ -146,7 +146,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "io"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
@@ -293,7 +293,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "mime"
-version = "2.12.1"
+version = "2.12.2"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -334,7 +334,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "task"
-version = "2.11.1"
+version = "2.11.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"},

--- a/ballerina/model-provider.bal
+++ b/ballerina/model-provider.bal
@@ -22,7 +22,7 @@ import ballerina/uuid;
 import ballerinax/mistral;
 
 const DEFAULT_MISTRAL_AI_SERVICE_URL = "https://api.mistral.ai/v1";
-const DEFAULT_MAX_TOKEN_COUNT = 512;
+const DEFAULT_MAX_TOKEN_COUNT = 4096;
 const DEFAULT_TEMPERATURE = 0.7d;
 
 # MistralAiProvider is a client class that provides an interface for interacting with Mistral AI Large Language Models.


### PR DESCRIPTION
## Purpose

Fixes: Increases the default maximum output token count from `512` to `4096` in the Mistral AI model provider to allow longer responses by default.

The previous default of `512` tokens was too restrictive for most real-world use cases, causing responses to be truncated. The new default of `4096` is well within the context window limits of all supported Mistral models (which range from 32,768 to 256,000 tokens) and better aligns with typical LLM usage patterns.

**Change:**
- `model-provider.bal`: Updated `DEFAULT_MAX_TOKEN_COUNT` from `512` → `4096`

**References**

https://docs.mistral.ai/models/overview

## Examples

```ballerina
// Before: maxTokens defaulted to 512, responses would get cut off
ModelProvider mistralClient = check new (
    apiKey = "your-api-key",
    modelType = MISTRAL_LARGE_LATEST
);

// After: maxTokens now defaults to 4096, allowing longer responses
// Users can still override it explicitly if needed:
ModelProvider mistralClient = check new (
    apiKey = "your-api-key",
    modelType = MISTRAL_LARGE_LATEST,
    maxTokens = 4096  // optional override
);



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary

This pull request increases the default maximum output token limit for the Mistral AI model provider from 512 to 4096 tokens. This change allows the model to generate longer responses by default while remaining within the supported context window of Mistral models. Users can continue to override the `maxTokens` parameter explicitly when initializing the ModelProvider if different limits are needed.

## Changes

**ballerina/model-provider.bal**
- Updated `DEFAULT_MAX_TOKEN_COUNT` from 512 to 4096

**ballerina/Dependencies.toml**
- Updated Ballerina package dependencies: `ballerina:http` (2.14.10 → 2.14.11), `ballerina:io` (1.8.0 → 1.8.1), `ballerina:mime` (2.12.1 → 2.12.2), and `ballerina:task` (2.11.1 → 2.11.2)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->